### PR TITLE
fix: build:clean script doesn't work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	],
 	"scripts": {
 		"compile": "tsc",
-		"build:clean": "rm -rf ./dist",
+		"build:clean": "tsx ./scripts/build-clean.ts",
 		"build": "pnpm build:clean && pnpm compile",
 		"test": "tsx --test ./src/**/*.test.ts",
 		"test:dev": "pnpm build && pnpm test",

--- a/scripts/build-clean.ts
+++ b/scripts/build-clean.ts
@@ -1,0 +1,4 @@
+import { rm } from "fs/promises";
+import { join } from "path";
+
+rm(join(process.cwd(), "dist"), { recursive: true, force: true });


### PR DESCRIPTION
Instead of using the linux-specific `rm -rf` command, uses node's built-in `fs.rm` function to recursively remove the dist directory.